### PR TITLE
FIX "logical-termination-point": "matr-1-0-0-http-c-odl-4-0-2-000" in MacAddressTableRecorder+config.yaml

### DIFF
--- a/spec/MacAddressTableRecorder+config.json
+++ b/spec/MacAddressTableRecorder+config.json
@@ -2872,7 +2872,7 @@
                   {
                     "local-id": "200",
                     "port-direction": "core-model-1-4:PORT_DIRECTION_TYPE_OUTPUT",
-                    "logical-termination-point": "matr-1-0-0-http-c-odl-4-0-2-000"
+                    "logical-termination-point": "matr-1-0-0-op-c-is-odl-4-0-2-000"
                   }
                 ]
               },


### PR DESCRIPTION
Fixes #140