### PR TITLE
Update MacAddressTableRecorder+config.json

### DIFF
--- a/spec/MacAddressTableRecorder+config.json
+++ b/spec/MacAddressTableRecorder+config.json
@@ -661,7 +661,7 @@
                 }
               }
             ]
-          }
+          },
           {
             "uuid": "matr-1-0-2-op-s-im-000",
             "ltp-direction": "core-model-1-4:TERMINATION_DIRECTION_SOURCE",


### PR DESCRIPTION
not yet merged to main official release 1-0-2_spec, but provides a fix for the "," missing there. fixes #246